### PR TITLE
Fixed Target_Print Nullptr error

### DIFF
--- a/code/game/g_target.cpp
+++ b/code/game/g_target.cpp
@@ -133,7 +133,8 @@ void Use_Target_Print (gentity_t *ent, gentity_t *other, gentity_t *activator)
 {
 	G_ActivateBehavior(ent,BSET_USE);
 
-	if ( activator->client ) {
+	if (activator 
+		&& activator->client ) {
 		gi.SendServerCommand( activator-g_entities, "cp \"%s\"", ent->message );
 	}
 }


### PR DESCRIPTION
Fixed a crash cause where a null activator entity (like a func_breakable) would activate a target_print entity and crash the game.