### PR TITLE
Various Consoles Commands

### DIFF
--- a/code/game/g_cmds.cpp
+++ b/code/game/g_cmds.cpp
@@ -1606,6 +1606,14 @@ void ClientCommand( int clientNum ) {
 			ent->client->ps.saberStylesKnown |= (1<<addStyle);
 		}
 	}
+	/* For UI -> CG Synchronisation */
+	else if (Q_stricmp(cmd, "syncsaberstyle") == 0)
+	{
+		ent = G_GetSelfForPlayerCmd();
+		if (ent->client->ps.saberAnimLevel != cg.saberAnimLevelPending) {
+			cg.saberAnimLevelPending = ent->client->ps.saberAnimLevel;
+		}
+	}
 	else if (Q_stricmp (cmd, "removesaberstyle") == 0)
 	{
 		ent = G_GetSelfForPlayerCmd();

--- a/code/game/g_cmds.cpp
+++ b/code/game/g_cmds.cpp
@@ -50,6 +50,7 @@ extern void ForceBlast(gentity_t *self);
 extern void G_CreateG2AttachedWeaponModel( gentity_t *ent, const char *psWeaponModel, int boltNum, int weaponNum );
 extern void G_StartMatrixEffect( gentity_t *ent, int meFlags = 0, int length = 1000, float timeScale = 0.0f, int spinTime = 0 );
 extern void ItemUse_Bacta(gentity_t *ent);
+extern void WP_DropWeapon_Configurable(gentity_t* dropper, vec3_t velocity, bool forceDropAll, bool deleteWeapon,bool forceNoWeapon);
 extern gentity_t *G_GetSelfForPlayerCmd( void );
 
 /*
@@ -1718,6 +1719,12 @@ void ClientCommand( int clientNum ) {
 	else if (Q_stricmp (cmd, "flushcam") == 0)
 	{
 		Cmd_FlushCamFile_f( ent );
+	}
+	else if (Q_stricmp(cmd, "dropcurrentweapon") == 0) {
+		WP_DropWeapon_Configurable(ent, NULL,true,false,false);
+	}
+	else if (Q_stricmp(cmd, "removecurrentweapon") == 0) {
+		WP_DropWeapon_Configurable(ent, NULL, true, true, false);
 	}
 	else if ( Q_stricmp( cmd, "dropsaber" ) == 0 )
 	{

--- a/code/game/g_cmds.cpp
+++ b/code/game/g_cmds.cpp
@@ -199,8 +199,6 @@ void G_Give( gentity_t *ent, const char *name, const char *args, int argc )
 	{
 		if (argc == 3)
 		{
-			ent->client->ps.stats[STAT_ARMOR] = atoi(args);
-
 			ent->client->ps.stats[STAT_ARMOR] = Com_Clampi(0, ent->client->ps.stats[STAT_MAX_HEALTH], atoi(args));
 		}
 		else
@@ -1606,6 +1604,31 @@ void ClientCommand( int clientNum ) {
 		if ( addStyle > SS_NONE && addStyle < SS_STAFF )
 		{
 			ent->client->ps.saberStylesKnown |= (1<<addStyle);
+		}
+	}
+	else if (Q_stricmp (cmd, "removesaberstyle") == 0)
+	{
+		ent = G_GetSelfForPlayerCmd();
+		if ( !ent || !ent->client )
+		{//wtf?
+			return;
+		}
+		if ( gi.argc() < 2 )
+		{
+			gi.SendServerCommand( ent-g_entities, va("print \"usage: remove <saber style>\n\""));
+			gi.SendServerCommand( ent-g_entities, va("print \"Valid styles: SS_FAST, SS_MEDIUM, SS_STRONG, SS_DESANN, SS_TAVION, SS_DUAL and SS_STAFF\n\""));
+			gi.SendServerCommand( ent-g_entities, va("print \"If no style are remaining, SS_MEDIUM will be set by default\n\""));
+			return;
+		}
+
+		int removeStyle = GetIDForString( SaberStyleTable, gi.argv(1) );
+		if (removeStyle > SS_NONE && removeStyle < SS_STAFF )
+		{
+			ent->client->ps.saberStylesKnown &= ~(1<<removeStyle);
+		}
+		if (ent->client->ps.saberStylesKnown == 0) {
+			ent->client->ps.saberStylesKnown = (1 << SS_MEDIUM);
+			cg.saberAnimLevelPending = ent->client->ps.saberAnimLevel = SS_MEDIUM;
 		}
 	}
 	else if (Q_stricmp (cmd, "setsaberstyle") == 0)

--- a/code/game/g_cmds.cpp
+++ b/code/game/g_cmds.cpp
@@ -50,7 +50,7 @@ extern void ForceBlast(gentity_t *self);
 extern void G_CreateG2AttachedWeaponModel( gentity_t *ent, const char *psWeaponModel, int boltNum, int weaponNum );
 extern void G_StartMatrixEffect( gentity_t *ent, int meFlags = 0, int length = 1000, float timeScale = 0.0f, int spinTime = 0 );
 extern void ItemUse_Bacta(gentity_t *ent);
-extern void WP_DropWeapon_Configurable(gentity_t* dropper, vec3_t velocity, bool forceDropAll, bool deleteWeapon,bool forceNoWeapon);
+extern void WP_DropWeapon_Configurable(gentity_t* dropper, vec3_t velocity, bool fromConsoleCommand, bool deleteWeapon,bool forceNoWeapon);
 extern gentity_t *G_GetSelfForPlayerCmd( void );
 
 /*

--- a/code/game/g_combat.cpp
+++ b/code/game/g_combat.cpp
@@ -129,7 +129,7 @@ Toss the weapon and powerups for the killed player
 */
 extern gentity_t *WP_DropThermal( gentity_t *ent );
 extern qboolean WP_SaberLose( gentity_t *self, vec3_t throwDir );
-gentity_t *TossClientItems( gentity_t *self )
+gentity_t* TossClientItems_Configurable(gentity_t* self,  bool dropOneSaber)
 {
 	//FIXME: drop left-hand weapon, too?
 	gentity_t	*dropped = NULL;
@@ -157,36 +157,47 @@ gentity_t *TossClientItems( gentity_t *self )
 
 	if ( weapon == WP_SABER )
 	{
+		//If I have no saber, don't matter
 		if ( self->weaponModel[0] < 0 )
-		{//don't have one in right hand
+		{
 			self->s.weapon = WP_NONE;
 		}
-		else if ( !(self->client->ps.saber[0].saberFlags&SFL_NOT_DISARMABLE)
-			|| g_saberPickuppableDroppedSabers->integer )
-		{//okay to drop it
+		//If it's called from DropWeapon Command, First drop the left saber.
+		else if (g_saberPickuppableDroppedSabers->integer && self->weaponModel[1] > 0 && dropOneSaber)
+		{
+			if (self->client->ps.saber[1].name && self->client->ps.saber[1].name[0]) {
+				//If drop is successfull then remove the saber from the player.
+				dropped = G_DropSaberItem(self->client->ps.saber[1].name, self->client->ps.saber[1].blade[0].color, self->client->renderInfo.handLPoint, self->client->ps.velocity, self->currentAngles);
+				if (dropped != NULL)
+				{
+					WP_RemoveSaber(self, 1);
+				}
+			}
+		}
+		//If it's called from DropWeapon Command, Secondly drop the right saber
+		else if (g_saberPickuppableDroppedSabers->integer && self->weaponModel[0] > 0 && dropOneSaber)
+		{
+			if (self->client->ps.saber[0].name && self->client->ps.saber[0].name[0]) {
+				//If drop is successfull then remove the saber from the player.
+				dropped = G_DropSaberItem(self->client->ps.saber[0].name, self->client->ps.saber[0].blade[0].color, self->client->renderInfo.handLPoint, self->client->ps.velocity, self->currentAngles);
+				if (dropped != NULL)
+				{
+					WP_RemoveSaber(self, 0);
+					self->s.weapon = WP_NONE;
+				}
+			}
+		}
+		//If it's death or other cause, drop both at once
+		else if ( !(self->client->ps.saber[0].saberFlags&SFL_NOT_DISARMABLE) || g_saberPickuppableDroppedSabers->integer)
+		{	//This code still look strange (but works x) )
 			if ( WP_SaberLose( self, NULL ) )
 			{
 				self->s.weapon = WP_NONE;
 			}
-		}
-		if ( g_saberPickuppableDroppedSabers->integer )
-		{//drop your left one, too
-			if ( self->weaponModel[1] >= 0 )
-			{//have one in left
-				if ( !(self->client->ps.saber[0].saberFlags&SFL_NOT_DISARMABLE)
-					|| g_saberPickuppableDroppedSabers->integer )
-				{//okay to drop it
-					//just drop an item
-					if ( self->client->ps.saber[1].name
-						&& self->client->ps.saber[1].name[0] )
-					{//have a valid string to use for saberType
-						//turn it into a pick-uppable item!
-						if ( G_DropSaberItem( self->client->ps.saber[1].name, self->client->ps.saber[1].blade[0].color, self->client->renderInfo.handLPoint, self->client->ps.velocity, self->currentAngles ) != NULL )
-						{//dropped it
-							WP_RemoveSaber( self, 1 );
-						}
-					}
-				}
+			if (g_saberPickuppableDroppedSabers->integer && self->weaponModel[1] > 0 && self->client->ps.saber[1].name && self->client->ps.saber[1].name[0] 
+				&& G_DropSaberItem(self->client->ps.saber[1].name, self->client->ps.saber[1].blade[0].color, self->client->renderInfo.handLPoint, self->client->ps.velocity, self->currentAngles) != NULL)
+			{
+				WP_RemoveSaber(self, 1);
 			}
 		}
 	}
@@ -368,6 +379,10 @@ gentity_t *TossClientItems( gentity_t *self )
 	}
 
 	return dropped;//NOTE: presumes only drop one thing
+}
+
+gentity_t* TossClientItems(gentity_t* self) {
+	return TossClientItems_Configurable(self, false);
 }
 
 void G_DropKey( gentity_t *self )

--- a/code/game/g_items.cpp
+++ b/code/game/g_items.cpp
@@ -814,6 +814,10 @@ void Touch_Item (gentity_t *ent, gentity_t *other, trace_t *trace) {
 		gi.Printf( "Touch_Item: %s is not an item!\n", ent->classname);
 		return;
 	}
+	//If the item was just dropped, should not be picked up before 1s
+	if (level.time - ent->s.time <= 1000) {
+		return;
+	}
 
 	if ( ent->item->giType == IT_WEAPON
 		&& ent->item->giTag == WP_SABER )

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -8384,14 +8384,10 @@ qboolean G_CheckEnemyPresence( gentity_t *ent, int dir, float radius, float tole
 	return qfalse;
 }
 //OTHER JEDI POWERS=========================================================================
-//OTHER JEDI POWERS=========================================================================
-//OTHER JEDI POWERS=========================================================================
-//OTHER JEDI POWERS=========================================================================
-//OTHER JEDI POWERS=========================================================================
-extern gentity_t *TossClientItems( gentity_t *self );
+extern gentity_t *TossClientItems_Configurable( gentity_t *self , bool fromConsoleCommand);
 extern void ChangeWeapon( gentity_t *ent, int newWeapon );
 
-void WP_DropWeapon_Configurable( gentity_t *dropper, vec3_t velocity, bool forceDropAll, bool deleteWeapon,bool forceNoWeapon)
+void WP_DropWeapon_Configurable( gentity_t *dropper, vec3_t velocity, bool fromConsoleCommand, bool deleteWeapon,bool forceNoWeapon)
 {
 	if ( !dropper || !dropper->client )
 	{
@@ -8399,11 +8395,19 @@ void WP_DropWeapon_Configurable( gentity_t *dropper, vec3_t velocity, bool force
 	}
 	int	replaceWeap = WP_NONE;
 	int oldWeap = dropper->s.weapon;
-	//Don't drop WP_MELEE 
-	if (oldWeap == WP_MELEE) {
+	//Don't drop WP_MELEE nor WP_NONE
+	if (oldWeap == WP_MELEE || oldWeap == WP_NONE) {
 		return;
 	}
-	gentity_t *weapon = TossClientItems( dropper );
+	bool isLeftSaber = false;
+	if (oldWeap == WP_SABER && dropper->weaponModel[1] > 0) {
+		isLeftSaber = true;
+	}
+	gentity_t *weapon = TossClientItems_Configurable( dropper , fromConsoleCommand);
+	//If the player did the drop, don't change weapon
+	if (isLeftSaber && fromConsoleCommand) {
+		return;
+	}
 	//Randomly, NPC will charge the player with melee (10%)
 	if ( (oldWeap == WP_THERMAL || (Q_irand(0, 99) < 10) ) && dropper->NPC && !forceNoWeapon )
 	{
@@ -8421,7 +8425,7 @@ void WP_DropWeapon_Configurable( gentity_t *dropper, vec3_t velocity, bool force
 	dropper->client->ps.weapons[replaceWeap] = 1;
 	if ( !dropper->s.number )
 	{
-		if ( oldWeap == WP_THERMAL && !forceDropAll)
+		if ( oldWeap == WP_THERMAL && !fromConsoleCommand)
 		{
 			dropper->client->ps.ammo[weaponData[oldWeap].ammoIndex] -= weaponData[oldWeap].energyPerShot;
 		}

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -8390,7 +8390,8 @@ qboolean G_CheckEnemyPresence( gentity_t *ent, int dir, float radius, float tole
 //OTHER JEDI POWERS=========================================================================
 extern gentity_t *TossClientItems( gentity_t *self );
 extern void ChangeWeapon( gentity_t *ent, int newWeapon );
-void WP_DropWeapon( gentity_t *dropper, vec3_t velocity )
+
+void WP_DropWeapon_Configurable( gentity_t *dropper, vec3_t velocity, bool forceDropAll, bool deleteWeapon,bool forceNoWeapon)
 {
 	if ( !dropper || !dropper->client )
 	{
@@ -8398,9 +8399,14 @@ void WP_DropWeapon( gentity_t *dropper, vec3_t velocity )
 	}
 	int	replaceWeap = WP_NONE;
 	int oldWeap = dropper->s.weapon;
+	//Don't drop WP_MELEE 
+	if (oldWeap == WP_MELEE) {
+		return;
+	}
 	gentity_t *weapon = TossClientItems( dropper );
-	if ( oldWeap == WP_THERMAL && dropper->NPC )
-	{//Hmm, maybe all NPCs should go into melee?  Not too many, though, or they mob you and look silly
+	//Randomly, NPC will charge the player with melee (10%)
+	if ( (oldWeap == WP_THERMAL || (Q_irand(0, 99) < 10) ) && dropper->NPC && !forceNoWeapon )
+	{
 		replaceWeap = WP_MELEE;
 	}
 	if ( dropper->ghoul2.IsValid() )
@@ -8415,7 +8421,7 @@ void WP_DropWeapon( gentity_t *dropper, vec3_t velocity )
 	dropper->client->ps.weapons[replaceWeap] = 1;
 	if ( !dropper->s.number )
 	{
-		if ( oldWeap == WP_THERMAL )
+		if ( oldWeap == WP_THERMAL && !forceDropAll)
 		{
 			dropper->client->ps.ammo[weaponData[oldWeap].ammoIndex] -= weaponData[oldWeap].energyPerShot;
 		}
@@ -8435,7 +8441,10 @@ void WP_DropWeapon( gentity_t *dropper, vec3_t velocity )
 	{
 		dropper->NPC->last_ucmd.weapon = replaceWeap;
 	}
-	if ( weapon != NULL && velocity && !VectorCompare( velocity, vec3_origin ) )
+	if ( weapon != NULL && deleteWeapon) {
+		G_FreeEntity(weapon);
+	}
+	else if ( weapon != NULL && velocity && !VectorCompare( velocity, vec3_origin ) )
 	{//weapon should have a direction to it's throw
 		VectorScale( velocity, 3, weapon->s.pos.trDelta );//NOTE: Presumes it is moving already...?
 		if ( weapon->s.pos.trDelta[2] < 150 )
@@ -8445,6 +8454,10 @@ void WP_DropWeapon( gentity_t *dropper, vec3_t velocity )
 		//FIXME: gets stuck inside it's former owner...
 		weapon->forcePushTime = level.time + 600; // let the push effect last for 600 ms
 	}
+}
+
+void WP_DropWeapon(gentity_t* dropper, vec3_t velocity) {
+	WP_DropWeapon_Configurable(dropper, velocity, false, false,false);
 }
 
 void WP_KnockdownTurret( gentity_t *self, gentity_t *pas )

--- a/code/qcommon/q_shared.cpp
+++ b/code/qcommon/q_shared.cpp
@@ -1093,6 +1093,30 @@ const char *GetStringForID( const stringID_table_t *table, int id )
 	return NULL;
 }
 
+char* Q_IntToBinaryString(int value) {
+	const int BITS = sizeof(int) * 8;
+
+	char* binaryString = new char[BITS + 1];
+	binaryString[BITS] = '\0';
+	for (int i = BITS - 1; i >= 0; --i) {
+		binaryString[i] = (value & 1) ? '1' : '0'; 
+		value >>= 1; 
+	}
+	return binaryString; 
+}
+
+int Q_FindFirstBitIndex(int bits) {
+	int i = 0;
+	while (bits > 0) {
+		if (bits & 1) {
+			return i+1;
+		}
+		bits >>= 1;
+		i++;
+	}
+	return 0;
+}
+
 qboolean Q_InBitflags( const uint32_t *bits, int index, uint32_t bitsPerByte ) {
 	return ( bits[index / bitsPerByte] & (1 << (index % bitsPerByte)) ) ? qtrue : qfalse;
 }

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -2820,6 +2820,20 @@ typedef enum
 
 } PlayerEffectFlags_e;
 
+/* Q_FindFirstBitIndex
+	Return the index of the first rightmost bit which is not 0.
+	011000 => 4
+	000110 => 2
+*/
+int Q_FindFirstBitIndex(int bits);
+
+/* Q_IntToBinaryString
+	Return an int in it's binary representation.
+	4 =>  00000100
+	15 => 00001111
+*/
+char* Q_IntToBinaryString(int value);
+
 qboolean Q_InBitflags( const uint32_t *bits, int index, uint32_t bitsPerByte );
 void Q_AddToBitflags( uint32_t *bits, int index, uint32_t bitsPerByte );
 void Q_RemoveFromBitflags( uint32_t *bits, int index, uint32_t bitsPerByte );

--- a/code/ui/ui_main.cpp
+++ b/code/ui/ui_main.cpp
@@ -5629,7 +5629,6 @@ static void UI_SwitchSaberStyle(const char* saberStyle) {
 
 	menuDef_t* menu;
 	short	stanceIndex = GetIDForString(SaberStyleTable, saberStyle);
-	Com_Printf("Asking to switch stance %s (%d)\n", saberStyle, stanceIndex);
 	menu = Menu_GetFocused();
 
 	if (!menu)
@@ -5644,7 +5643,7 @@ static void UI_SwitchSaberStyle(const char* saberStyle) {
 
 	/* Should the player be allowed to play with this in with dual or staff saber? May be it could be interesting to have Fast/Strong + Staff/Dual but
 		I don't think the engine would allow this. Cycle Saber Attack should be updated to reflect this kind of changes first*/
-	if ((Q_stricmp(Cvar_VariableString("g_saber_type"), "single") || Q_stricmp(Cvar_VariableString("g_saber_type"), ""))) {
+	if (!(Q_stricmp(Cvar_VariableString("g_saber_type"), "single") || Q_stricmp(Cvar_VariableString("g_saber_type"), ""))) {
 		return;
 	}
 

--- a/code/ui/ui_main.cpp
+++ b/code/ui/ui_main.cpp
@@ -118,6 +118,8 @@ static void		UI_UpdateSaberCvars ( void );
 static void		UI_GetSaberCvars ( void );
 static void		UI_ResetSaberCvars ( void );
 static void		UI_InitAllocForcePowers ( const char *forceName );
+static void		UI_InitAllocSaberStyle( const char *saberStyle );
+static void		UI_SwitchSaberStyle( const char * saberStyle);
 static void		UI_AffectForcePowerLevel ( const char *forceName );
 static void		UI_ShowForceLevelDesc ( const char *forceName );
 static void		UI_ResetForceLevels ( void );
@@ -705,6 +707,27 @@ static missionData_t missionData[MAX_MISSION_TOPIC][MAX_MISSION] =
 	{ NULL,			NULL,		NULL, NULL, NULL, qfalse},
 	{ NULL,			NULL,		NULL, NULL, NULL, qfalse},
 },
+};
+
+
+stringID_table_t SaberStyleTable[] =
+{
+	{ "NULL",SS_NONE },
+	ENUM2STRING(SS_FAST),
+	{ "fast",SS_FAST },
+	ENUM2STRING(SS_MEDIUM),
+	{ "medium",SS_MEDIUM },
+	ENUM2STRING(SS_STRONG),
+	{ "strong",SS_STRONG },
+	ENUM2STRING(SS_DESANN),
+	{ "desann",SS_DESANN },
+	ENUM2STRING(SS_TAVION),
+	{ "tavion",SS_TAVION },
+	ENUM2STRING(SS_DUAL),
+	{ "dual",SS_DUAL },
+	ENUM2STRING(SS_STAFF),
+	{ "staff",SS_STAFF },
+	{ "", 0 },
 };
 
 static int gamecodetoui[] = {4,2,3,0,5,1,6};
@@ -1852,6 +1875,20 @@ static qboolean UI_RunMenuScript ( const char **args )
 			String_Parse(args, &forceName);
 
 			UI_InitAllocForcePowers(forceName);
+		}
+		else if (Q_stricmp(name, "initallocsaberstyle") == 0)
+		{
+			const char *saberStyle;
+			String_Parse(args, &saberStyle);
+
+			UI_InitAllocSaberStyle(saberStyle);
+		}
+		else if (Q_stricmp(name, "switchsaberstyle") == 0)
+		{
+			const char *saberStyle;
+			String_Parse(args, &saberStyle);
+
+			UI_SwitchSaberStyle(saberStyle);
 		}
 		else if (Q_stricmp(name, "getNPCcode") == 0)
 		{
@@ -5544,6 +5581,99 @@ static qboolean UI_GetForcePowerIndex ( const char *forceName, short *forcePower
 	*forcePowerI = FP_UPDATED_NONE;	// Didn't find it
 
 	return(qfalse);
+}
+
+// Set the fields for the allocation of Saber Style(Used by Force Power Allocation screen)
+static void UI_InitAllocSaberStyle(const char* saberStyle) {
+
+	menuDef_t* menu;
+	itemDef_t* item;
+	short	stanceIndex = GetIDForString(SaberStyleTable, saberStyle);;
+
+	menu = Menu_GetFocused();	// Get current menu
+
+	if (!menu)
+	{
+		return;
+	}
+
+	if (stanceIndex <= 0 || stanceIndex >= SS_NUM_SABER_STYLES)
+	{
+		return;
+	}
+
+	client_t* cl = &svs.clients[0];	// 0 because only ever us as a player
+	if (!cl) {
+		return;
+	}
+	playerState_t* pState = cl->gentity->client;
+	bool hasStance = (pState->saberStylesKnown & 1 << stanceIndex) != 0;
+	bool isSingleSaber = !Q_stricmp(Cvar_VariableString("g_saber_type"), "single");
+
+	char itemName[128];
+	Com_sprintf(itemName, sizeof(itemName), "%s_switch", saberStyle);
+	item = (itemDef_s*)Menu_FindItemByName(menu, itemName);
+
+	if (item)
+	{
+		char itemGraphic[128];
+		Com_sprintf(itemGraphic, sizeof(itemGraphic), "gfx/menus/stance_switch_%s", hasStance ? "on" : "off");
+		item->window.background = ui.R_RegisterShaderNoMip(itemGraphic);
+		item->disabled = isSingleSaber? qfalse : qtrue;
+		item->disabledHidden = qfalse;
+	}
+}
+
+// Switch the value of a Saber Style then call update method to update UI(Used by Force Power Allocation screen)
+static void UI_SwitchSaberStyle(const char* saberStyle) {
+
+	menuDef_t* menu;
+	short	stanceIndex = GetIDForString(SaberStyleTable, saberStyle);
+	Com_Printf("Asking to switch stance %s (%d)\n", saberStyle, stanceIndex);
+	menu = Menu_GetFocused();
+
+	if (!menu)
+	{
+		return;
+	}
+
+	if (stanceIndex <= 0 || stanceIndex >= SS_NUM_SABER_STYLES)
+	{
+		return;
+	}
+
+	/* Should the player be allowed to play with this in with dual or staff saber? May be it could be interesting to have Fast/Strong + Staff/Dual but
+		I don't think the engine would allow this. Cycle Saber Attack should be updated to reflect this kind of changes first*/
+	if ((Q_stricmp(Cvar_VariableString("g_saber_type"), "single") || Q_stricmp(Cvar_VariableString("g_saber_type"), ""))) {
+		return;
+	}
+
+	client_t* cl = &svs.clients[0];	// 0 because only ever us as a player
+	if (!cl) {
+		return;
+	}
+
+	playerState_t* pState = cl->gentity->client;
+	bool hasStance = (pState->saberStylesKnown & (1 << stanceIndex) ) != 0;
+	//Add or remove the stance
+	if (hasStance) {
+		int newStanceMap = pState->saberStylesKnown & ~(1 << stanceIndex);
+		if (newStanceMap > 1) {
+			pState->saberStylesKnown = newStanceMap;
+			//If the actual saber style is removed, we need to switch to another.
+			if (pState->saberAnimLevel == stanceIndex) {
+				//Right shift because there is always a left shift before setting. also Sometimes the player start with 1 in this map?
+				int newStance = Q_FindFirstBitIndex(newStanceMap>>1) ;
+				pState->saberAnimLevel = newStance;
+			}
+		}
+		
+	}
+	else {
+		pState->saberStylesKnown |= (1 << stanceIndex);
+	}
+
+	return UI_InitAllocSaberStyle(saberStyle);
 }
 
 // Set the fields for the allocation of force powers (Used by Force Power Allocation screen)

--- a/code/ui/ui_main.cpp
+++ b/code/ui/ui_main.cpp
@@ -5587,7 +5587,7 @@ static void UI_InitAllocForcePowers ( const char *forceName )
 	if (item)
 	{
 		char itemGraphic[128];
-		Com_sprintf (itemGraphic, sizeof(itemGraphic), "gfx/menus/hex_pattern_%d",forcelevel >= 4 ? 3 : forcelevel);
+		Com_sprintf (itemGraphic, sizeof(itemGraphic), "gfx/menus/hex_pattern_%d",forcelevel >= 6 ? 5 : forcelevel);
 		item->window.background = ui.R_RegisterShaderNoMip(itemGraphic);
 
 		// If maxed out on power - don't allow update


### PR DESCRIPTION
Add commands :
- DropCurrentWeapon : Drop the current weapon. If weapon is lightsaber, it only drop one (the left one first, then the right one).
- RemoveCurrentWeapon : Delete the current Weapon (Drop it then remove the dropped entity)
- removeSaberStyle : Remove a saber style from the saberStyle bitmap
- NPC may randomly switch to WP_MELEE instead of WP_NONE (very low chance) when they are disarmed
- SyncSaberStyle : Allow to force update saber style from playerstate to gc.

Add UI Scripts :
- UI_InitAllocSaberStyle : to update the UI of saberstyle known
- UI_SwitchSaberStyle : switch a specific saberstyle.

Specific changes
- WP_DropWeapon_Configurable was created to allow the use of one method to handle the uses cases.
- TossClientItems_Configurable was createdto allow it to be called from console command without refactoring all code.
- Touch_Item was modified to avoid that the player imediately picking up the dropped weapon (1s cooldown)
- UI_InitAllocForcePowers will now allow force power up to five (for menu that would need it)
- A redudant line in give shield/armor code was removed.
- Add two utility methods to q_shared related to bitwise operations.