### PR TITLE
Solving : Picking up blasters keeps resetting ammo

### DIFF
--- a/code/game/g_items.cpp
+++ b/code/game/g_items.cpp
@@ -137,9 +137,13 @@ int Pickup_Holdable( gentity_t *ent, gentity_t *other )
 //======================================================================
 int Add_Ammo2 (gentity_t *ent, int ammoType, int count)
 {
-
 	if (ammoType != AMMO_FORCE)
 	{
+		if (ent->client->ps.ammo[ammoType] > ammoData[ammoType].max)
+		{
+			return qfalse;
+		}
+
 		ent->client->ps.ammo[ammoType] += count;
 
 		// since the ammo is the weapon in this case, picking up ammo should actually give you the weapon


### PR DESCRIPTION
Changes : 
- Check if currentAmmo is over max before the increase, and do nothing if it is